### PR TITLE
[SCIIASA-13] validates environmental variables with @t3-oss

### DIFF
--- a/client/next.config.js
+++ b/client/next.config.js
@@ -1,0 +1,14 @@
+import { fileURLToPath } from "node:url";
+import { createJiti } from "jiti";
+const jiti = createJiti(fileURLToPath(import.meta.url));
+
+await jiti.import("./src/env");
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  poweredByHeader: false,
+  output: "standalone",
+  transpilePackages: ["@t3-oss/env-nextjs", "@t3-oss/env-core"],
+};
+
+export default nextConfig;

--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -1,8 +1,0 @@
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
-  poweredByHeader: false,
-  output: "standalone",
-};
-
-export default nextConfig;

--- a/client/package.json
+++ b/client/package.json
@@ -2,6 +2,7 @@
   "name": "scenario-compass-platform-client",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
@@ -16,13 +17,16 @@
     "@radix-ui/react-select": "2.2.5",
     "@radix-ui/react-slot": "1.2.3",
     "@radix-ui/react-visually-hidden": "1.2.3",
+    "@t3-oss/env-nextjs": "0.13.8",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
+    "jiti": "2.4.2",
     "lucide-react": "0.524.0",
     "next": "15.3.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "tailwind-merge": "3.3.1"
+    "tailwind-merge": "3.3.1",
+    "zod": "3.25.71"
   },
   "devDependencies": {
     "@eslint/eslintrc": "3.3.1",

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -20,12 +20,18 @@ importers:
       '@radix-ui/react-visually-hidden':
         specifier: 1.2.3
         version: 1.2.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@t3-oss/env-nextjs':
+        specifier: 0.13.8
+        version: 0.13.8(typescript@5.8.3)(zod@3.25.71)
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
       clsx:
         specifier: 2.1.1
         version: 2.1.1
+      jiti:
+        specifier: 2.4.2
+        version: 2.4.2
       lucide-react:
         specifier: 0.524.0
         version: 0.524.0(react@19.1.0)
@@ -41,6 +47,9 @@ importers:
       tailwind-merge:
         specifier: 3.3.1
         version: 3.3.1
+      zod:
+        specifier: 3.25.71
+        version: 3.25.71
     devDependencies:
       '@eslint/eslintrc':
         specifier: 3.3.1
@@ -1088,6 +1097,40 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@t3-oss/env-core@0.13.8':
+    resolution: {integrity: sha512-L1inmpzLQyYu4+Q1DyrXsGJYCXbtXjC4cICw1uAKv0ppYPQv656lhZPU91Qd1VS6SO/bou1/q5ufVzBGbNsUpw==}
+    peerDependencies:
+      arktype: ^2.1.0
+      typescript: '>=5.0.0'
+      valibot: ^1.0.0-beta.7 || ^1.0.0
+      zod: ^3.24.0 || ^4.0.0-beta.0
+    peerDependenciesMeta:
+      arktype:
+        optional: true
+      typescript:
+        optional: true
+      valibot:
+        optional: true
+      zod:
+        optional: true
+
+  '@t3-oss/env-nextjs@0.13.8':
+    resolution: {integrity: sha512-QmTLnsdQJ8BiQad2W2nvV6oUpH4oMZMqnFEjhVpzU0h3sI9hn8zb8crjWJ1Amq453mGZs6A4v4ihIeBFDOrLeQ==}
+    peerDependencies:
+      arktype: ^2.1.0
+      typescript: '>=5.0.0'
+      valibot: ^1.0.0-beta.7 || ^1.0.0
+      zod: ^3.24.0 || ^4.0.0-beta.0
+    peerDependenciesMeta:
+      arktype:
+        optional: true
+      typescript:
+        optional: true
+      valibot:
+        optional: true
+      zod:
+        optional: true
 
   '@tailwindcss/node@4.1.11':
     resolution: {integrity: sha512-yzhzuGRmv5QyU9qLNg4GTlYI6STedBWRE7NjxP45CsFYYq9taI0zJXZBMqIC/c8fViNLhmrbpSFS57EoxUmD6Q==}
@@ -3353,6 +3396,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.25.71:
+    resolution: {integrity: sha512-BsBc/NPk7h8WsUWYWYL+BajcJPY8YhjelaWu2NMLuzgraKAz4Lb4/6K11g9jpuDetjMiqhZ6YaexFLOC0Ogi3Q==}
+
 snapshots:
 
   '@adobe/css-tools@4.4.3': {}
@@ -4149,6 +4195,18 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@t3-oss/env-core@0.13.8(typescript@5.8.3)(zod@3.25.71)':
+    optionalDependencies:
+      typescript: 5.8.3
+      zod: 3.25.71
+
+  '@t3-oss/env-nextjs@0.13.8(typescript@5.8.3)(zod@3.25.71)':
+    dependencies:
+      '@t3-oss/env-core': 0.13.8(typescript@5.8.3)(zod@3.25.71)
+    optionalDependencies:
+      typescript: 5.8.3
+      zod: 3.25.71
 
   '@tailwindcss/node@4.1.11':
     dependencies:
@@ -6634,3 +6692,5 @@ snapshots:
   yaml@2.8.0: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.71: {}

--- a/client/src/env.ts
+++ b/client/src/env.ts
@@ -1,0 +1,18 @@
+import { createEnv } from "@t3-oss/env-nextjs";
+import { z } from "zod/v4";
+
+export const env = createEnv({
+  server: {},
+  client: {
+    NEXT_PUBLIC_API_CREDENTIALS: z.string().regex(/;/, {
+      message: "NEXT_PUBLIC_API_CREDENTIALS must be in the format 'username;password'",
+    }),
+    NEXT_PUBLIC_API_APP_NAME: z.string(),
+    NEXT_PUBLIC_API_BASE_URL: z.url(),
+  },
+  runtimeEnv: {
+    NEXT_PUBLIC_API_CREDENTIALS: process.env.NEXT_PUBLIC_API_CREDENTIALS,
+    NEXT_PUBLIC_API_APP_NAME: process.env.NEXT_PUBLIC_API_APP_NAME,
+    NEXT_PUBLIC_API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL,
+  },
+});


### PR DESCRIPTION
This pull request refactors the Next.js configuration by switching from TypeScript to JavaScript, introduces environment variable validation using `@t3-oss/env-nextjs` and `zod`, and updates dependencies to support these changes. The most important changes include the migration of `next.config.ts` to `next.config.js`, the addition of environment validation logic, and updates to `package.json` and `pnpm-lock.yaml` to include new dependencies.

### Configuration Refactor:
* Migrated `next.config.ts` to `next.config.js`, switching from TypeScript to JavaScript. The new configuration disables the `poweredByHeader`, sets the output mode to `standalone`, and transpiles packages `@t3-oss/env-nextjs` and `@t3-oss/env-core`. (`client/next.config.js` [[1]](diffhunk://#diff-6a52ebdee5662eb75f6f3010d0aca4b33d708e85c7203d00cf50b1109480ae16R1-R14)], `client/next.config.ts` [[2]](diffhunk://#diff-bb35b6fdef8ccbdb298704909e9b797f5a5112ff6afb9be72c7110001dec9fb6L1-L8)])

### Environment Variable Validation:
* Added `client/src/env.ts` to validate environment variables using `@t3-oss/env-nextjs` and `zod`. This ensures proper formatting and type safety for variables such as `NEXT_PUBLIC_API_CREDENTIALS`, `NEXT_PUBLIC_API_APP_NAME`, and `NEXT_PUBLIC_API_BASE_URL`. (`client/src/env.ts` [[client/src/env.tsR1-R18](diffhunk://#diff-a7990855d20a847fd4bb85514b83e09380f49fccf3581dff18686d806becc0f5R1-R18)])

### Dependency Updates:
* Updated `client/package.json` to include new dependencies: `@t3-oss/env-nextjs`, `jiti`, and `zod`. Also added `"type": "module"` to enable ES module syntax. (`client/package.json` [[1]](diffhunk://#diff-1846122c2c83a486a3693f7966aa522c34cf489f674185c4da0d9221683fd81fR5)], [[2]](diffhunk://#diff-1846122c2c83a486a3693f7966aa522c34cf489f674185c4da0d9221683fd81fR18-R27)])
* Updated `client/pnpm-lock.yaml` to reflect the addition of `@t3-oss/env-nextjs`, `@t3-oss/env-core`, and `zod` dependencies, along with their peer dependencies and resolutions. (`client/pnpm-lock.yaml` [[1]](diffhunk://#diff-c12df9938fa339a59c3674577dfca7469ab6b89e85bb60376c998a820d79eb91R17-R28)], [[2]](diffhunk://#diff-c12df9938fa339a59c3674577dfca7469ab6b89e85bb60376c998a820d79eb91R44-R46)], [[3]](diffhunk://#diff-c12df9938fa339a59c3674577dfca7469ab6b89e85bb60376c998a820d79eb91R1069-R1102)], [[4]](diffhunk://#diff-c12df9938fa339a59c3674577dfca7469ab6b89e85bb60376c998a820d79eb91R3367-R3369)], [[5]](diffhunk://#diff-c12df9938fa339a59c3674577dfca7469ab6b89e85bb60376c998a820d79eb91R4135-R4146)], [[6]](diffhunk://#diff-c12df9938fa339a59c3674577dfca7469ab6b89e85bb60376c998a820d79eb91R6631-R6632)])