### PR TITLE
Update Nature editorial policy link

### DIFF
--- a/client/src/app/license/page.tsx
+++ b/client/src/app/license/page.tsx
@@ -30,7 +30,7 @@ export default function LicensePage() {
           <Heading variant="dark" size="5xl" as="h1" id="hero-title" className="text-left">
             License
           </Heading>
-          <h2 className="text-background h-20 text-xl leading-7 lg:w-2/5"></h2>
+          <div aria-hidden="true" className="h-20 lg:w-2/5" />
         </div>
       </div>
       <section className="flex w-full flex-col items-center bg-white">
@@ -46,7 +46,7 @@ export default function LicensePage() {
             The data may be used for scientific research purposes. However, users must strictly
             adhere to the applicable{" "}
             <Link
-              href="https://www.nature.com/nature-portfolio/editorial-policies/preprints-and-conference-proceedings"
+              href="https://www.nature.com/nature-portfolio/editorial-policies/press-and-embargo-policies"
               target="_blank"
               rel="noopener noreferrer"
               className="underline"

--- a/client/src/components/custom/embargo-pop-up.tsx
+++ b/client/src/components/custom/embargo-pop-up.tsx
@@ -96,7 +96,7 @@ export function EmbargoPopUp() {
           The data may be used for scientific research purposes. However, users must strictly adhere
           to the applicable{" "}
           <Link
-            href="https://www.nature.com/nature-portfolio/editorial-policies/preprints-and-conference-proceedings"
+            href="https://www.nature.com/nature-portfolio/editorial-policies/press-and-embargo-policies"
             target="_blank"
             rel="noopener noreferrer"
             className="underline"


### PR DESCRIPTION
## Summary
- Update both Nature editorial policy links to the current press and embargo policies page
- Replace an empty spacer heading on the license page with an aria-hidden spacer element

Fixes #164

## Verification
- `curl -s -L -o /dev/null -w 'old %{http_code} %{url_effective}\\n' https://www.nature.com/nature-portfolio/editorial-policies/preprints-and-conference-proceedings` -> `old 404 ...preprints-and-conference-proceedings?...`
- `curl -s -L -o /dev/null -w 'new %{http_code} %{url_effective}\\n' https://www.nature.com/nature-portfolio/editorial-policies/press-and-embargo-policies` -> `new 200 ...press-and-embargo-policies?...`
- `rg -n "preprints-and-conference-proceedings" .` -> no matches
- `git diff --check` -> passed

Note: I attempted `pnpm install --frozen-lockfile --ignore-scripts` with a temporary pnpm store, but the install did not exit after package linking completed and was interrupted before tests could be run.