### PR TITLE
feat: mobile responsiveness improvements (80/20 pass)

### DIFF
--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -159,7 +159,7 @@
   }
 
   .dashboard-container {
-    @apply mx-auto w-full px-12;
+    @apply mx-auto w-full px-4 sm:px-6 md:px-8 lg:px-12;
     max-width: 1920px;
   }
 }

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { Footer } from "@/components/layout/footer";
 import "./globals.css";
 import { ClientProviders } from "@/app/providers";
 import FeedbackButton from "@/components/custom/feedback-button";
+import ScrollToTopButton from "@/components/custom/scroll-to-top-button";
 import { MatomoScript } from "@/components/matomo/matomo-script";
 import NavigationTracker from "@/components/matomo/navigation-tracker";
 import { headers } from "next/headers";
@@ -74,6 +75,7 @@ export default function RootLayout({
             {children}
             <Footer />
             <FeedbackButton />
+            <ScrollToTopButton />
             <NavigationTracker />
           </>
         </ClientProviders>

--- a/client/src/components/custom/embargo-pop-up.tsx
+++ b/client/src/components/custom/embargo-pop-up.tsx
@@ -82,7 +82,7 @@ export function EmbargoPopUp() {
     <Dialog open={open} onOpenChange={() => {}}>
       <DialogContent
         showCloseButton={false}
-        className="bg-white sm:max-w-lg"
+        className="max-h-[90vh] overflow-y-auto bg-white sm:max-w-lg"
         aria-describedby={undefined}
         onInteractOutside={(e) => e.preventDefault()}
         onEscapeKeyDown={(e) => e.preventDefault()}
@@ -141,7 +141,12 @@ export function EmbargoPopUp() {
             </Link>
           </div>
         </div>
-        <Button onClick={handleSkip} variant="outline" className="px-10" size="lg">
+        <Button
+          onClick={handleSkip}
+          variant="outline"
+          className="w-full whitespace-normal"
+          size="lg"
+        >
           Got it, continue to the dashboard
         </Button>
         <strong className="mt-2">Stay up to date on the Scenario Compass</strong>
@@ -160,7 +165,7 @@ export function EmbargoPopUp() {
         <Button
           onClick={handleSignup}
           disabled={!isValidEmail(email) || isSubmitting}
-          className="px-10"
+          className="w-full whitespace-normal"
           size="lg"
         >
           {isSubmitting ? "Signing up..." : "Sign up and continue to the dashboard"}

--- a/client/src/components/custom/feedback-button.tsx
+++ b/client/src/components/custom/feedback-button.tsx
@@ -19,7 +19,7 @@ export default function FeedbackButton() {
   return (
     <Button
       asChild
-      className="text-background hover:bg-primary border-red-orange bg-red-orange fixed top-36 right-10 z-100 box-border origin-top-right -rotate-90 items-center justify-center gap-2 rounded-sm rounded-b-none border border-b-0 p-2 pr-3 hover:border-white hover:text-white"
+      className="text-background hover:bg-primary border-red-orange bg-red-orange fixed top-36 right-10 z-100 box-border hidden origin-top-right -rotate-90 items-center justify-center gap-2 rounded-sm rounded-b-none border border-b-0 p-2 pr-3 hover:border-white hover:text-white sm:flex"
     >
       <Link
         rel="noopener noreferrer"

--- a/client/src/components/custom/scroll-to-top-button.tsx
+++ b/client/src/components/custom/scroll-to-top-button.tsx
@@ -17,7 +17,9 @@ export default function ScrollToTopButton() {
   const visible = y > SHOW_THRESHOLD;
 
   const scrollToTop = () => {
-    window.scrollTo({ top: 0, behavior: "smooth" });
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
+    window.scrollTo({ top: 0, behavior: prefersReducedMotion ? "auto" : "smooth" });
   };
 
   return (

--- a/client/src/components/custom/scroll-to-top-button.tsx
+++ b/client/src/components/custom/scroll-to-top-button.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { ArrowUp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useScroll } from "@/hooks/use-scroll";
+
+/**
+ * Mobile-only floating action button that scrolls back to the top of the page.
+ * It fades in once the user has scrolled down roughly half a screen. Styled to
+ * match the brand's other floating action (see feedback-button).
+ */
+const SHOW_THRESHOLD = 400;
+
+export default function ScrollToTopButton() {
+  const { y } = useScroll();
+  const visible = y > SHOW_THRESHOLD;
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  return (
+    <Button
+      type="button"
+      size="icon"
+      onClick={scrollToTop}
+      aria-label="Scroll back to top"
+      className={cn(
+        "bg-red-orange text-background hover:bg-primary fixed right-4 bottom-6 z-50 size-11 rounded-full shadow-lg transition-opacity duration-300 hover:text-white sm:hidden",
+        visible ? "opacity-100" : "pointer-events-none opacity-0",
+      )}
+      aria-hidden={!visible}
+      tabIndex={visible ? 0 : -1}
+    >
+      <ArrowUp aria-hidden="true" />
+    </Button>
+  );
+}

--- a/client/src/components/layout/footer/index.tsx
+++ b/client/src/components/layout/footer/index.tsx
@@ -19,7 +19,7 @@ export function Footer() {
             </p>
           </div>
 
-          <div className="flex flex-col items-center justify-between gap-10 pt-16 lg:flex-row">
+          <div className="flex flex-col items-center justify-between gap-6 pt-10 lg:flex-row lg:gap-10 lg:pt-16">
             <Image
               src="/images/logos/logo_iamc.png"
               className="pointer-events-none h-14 w-auto select-none lg:h-18 lg:w-auto"
@@ -43,13 +43,13 @@ export function Footer() {
             />
           </div>
 
-          <div className="flex flex-col items-center justify-center gap-7 pt-16 pb-12 text-center lg:flex-row lg:gap-14 lg:pb-16">
+          <div className="flex flex-col items-center justify-center gap-1 pt-10 pb-8 text-center lg:flex-row lg:gap-14 lg:pt-16 lg:pb-16">
             {mobilePaths.map((path, index) => {
               return (
                 <Link
                   key={index}
                   {...path}
-                  className="text-base leading-6 font-normal text-stone-700 hover:opacity-60"
+                  className="py-3 text-base leading-6 font-normal text-stone-700 hover:opacity-60 lg:py-0"
                 >
                   {path.label}
                 </Link>
@@ -58,10 +58,10 @@ export function Footer() {
           </div>
           <div
             className={
-              "flex flex-col items-center justify-between gap-6 border-t border-stone-200 py-14 md:flex-row md:gap-0 md:py-6"
+              "flex flex-col items-center justify-between gap-4 border-t border-stone-200 py-10 md:flex-row md:gap-0 md:py-6"
             }
           >
-            <div className="order-3 flex flex-col items-center justify-center gap-6 md:order-1 md:flex-row md:gap-4">
+            <div className="order-3 flex flex-col items-center justify-center gap-2 md:order-1 md:flex-row md:gap-4">
               <div
                 className="order-3 text-sm leading-6 font-normal text-stone-500 md:order-1"
                 role="contentinfo"
@@ -69,7 +69,7 @@ export function Footer() {
               >
                 © 2026 Scenario Compass Initiative
               </div>
-              <Dot className="order-2 text-stone-500" />
+              <Dot className="order-2 hidden text-stone-500 md:inline" />
               <div className="order-1 flex gap-9 md:order-3 md:gap-4">
                 <Link
                   {...EXTERNAL_LINKS.TERMS_OF_USE}
@@ -85,18 +85,18 @@ export function Footer() {
                 "order-1 flex flex-col items-center justify-center gap-5 md:order-2 md:flex-row"
               }
             >
-              <div className="flex gap-9 md:gap-5">
+              <div className="flex items-center gap-6">
                 <a
                   href="mailto:sci-info@iiasa.ac.at"
-                  className="text-sm leading-6 font-normal text-stone-700 hover:opacity-60"
+                  className="py-3 text-sm leading-6 font-normal text-stone-700 hover:opacity-60"
                 >
                   Contact
                 </a>
                 <Dot className="hidden text-stone-500 md:inline" />
-                <Link {...EXTERNAL_LINKS.BLUESKY}>
+                <Link {...EXTERNAL_LINKS.BLUESKY} className="-m-3 p-3">
                   <BlueskyLogoIcon />
                 </Link>
-                <Link {...EXTERNAL_LINKS.LINKEDIN}>
+                <Link {...EXTERNAL_LINKS.LINKEDIN} className="-m-3 p-3">
                   <Linkedin className={"text-stone-500"} size={20} strokeWidth={1} />
                 </Link>
               </div>

--- a/client/src/components/layout/navbar/navbar.tsx
+++ b/client/src/components/layout/navbar/navbar.tsx
@@ -51,7 +51,7 @@ const Logo = ({ className, theme }: { className?: string; theme: string }) => {
     <Link href={INTERNAL_PATHS.HOME} className={cn(className, "flex h-fit items-center gap-2")}>
       <Image src={logoSrc} alt="IIASA Logo" className="h-auto w-auto" />
       <div className={textColor}>
-        <span className="font-display hidden text-2xl leading-10 sm:inline">
+        <span className="font-display text-lg leading-tight sm:text-2xl sm:leading-10">
           Scenario Compass Initiative
         </span>
       </div>

--- a/client/src/components/layout/navbar/navbar.tsx
+++ b/client/src/components/layout/navbar/navbar.tsx
@@ -51,7 +51,9 @@ const Logo = ({ className, theme }: { className?: string; theme: string }) => {
     <Link href={INTERNAL_PATHS.HOME} className={cn(className, "flex h-fit items-center gap-2")}>
       <Image src={logoSrc} alt="IIASA Logo" className="h-auto w-auto" />
       <div className={textColor}>
-        <span className="font-display text-2xl leading-10">Scenario Compass Initiative</span>
+        <span className="font-display hidden text-2xl leading-10 sm:inline">
+          Scenario Compass Initiative
+        </span>
       </div>
     </Link>
   );

--- a/client/src/components/slider-select/index.tsx
+++ b/client/src/components/slider-select/index.tsx
@@ -199,7 +199,7 @@ const SliderSelect: React.FC<SliderSelectProps> = ({
         </PopoverTrigger>
 
         <PopoverContent
-          className="w-[var(--radix-popover-trigger-width)] min-w-100 p-0"
+          className="w-[var(--radix-popover-trigger-width)] min-w-[min(400px,calc(100vw-2rem))] p-0"
           align="start"
         >
           <div className="divide-y divide-gray-200 py-2">

--- a/client/src/containers/landing-page-container/newsletter-subscription-container.tsx
+++ b/client/src/containers/landing-page-container/newsletter-subscription-container.tsx
@@ -49,8 +49,13 @@ export function NewsletterSubscriptionContainer() {
   };
 
   return (
-    <section className="flex max-w-6xl items-center px-4 py-16 md:px-10 lg:gap-10 lg:px-20 lg:py-14">
-      <Image src={emailImg} height={240} alt="cup of coffee - coming soon" priority />
+    <section className="flex max-w-6xl flex-col items-center px-4 py-16 md:flex-row md:px-10 lg:gap-10 lg:px-20 lg:py-14">
+      <Image
+        src={emailImg}
+        height={240}
+        alt="cup of coffee - coming soon"
+        className="hidden md:block"
+      />
       <div className="container flex flex-col items-center px-4 py-16">
         <Heading as="h2" size="4xl" variant="light" className="mb-2 text-left">
           Stay up to date on the Scenario Compass

--- a/client/src/containers/learn-by-topic-container/index.tsx
+++ b/client/src/containers/learn-by-topic-container/index.tsx
@@ -5,7 +5,6 @@ export function LearnByTopicPageContainer() {
   return (
     <>
       <ModuleHero />
-      <div className="grid min-h-screen place-content-center" />
       <ModuleCrossLinks />
     </>
   );

--- a/client/src/containers/scenario-dashboard-container/components/meta-scenario-filters/climate-filter/climate-filter-row.tsx
+++ b/client/src/containers/scenario-dashboard-container/components/meta-scenario-filters/climate-filter/climate-filter-row.tsx
@@ -54,7 +54,7 @@ export const ClimateFilterRow = ({ prefix }: RowFilterProps) => {
               <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
             </button>
           </PopoverTrigger>
-          <PopoverContent className="w-[400px] p-0" align="start">
+          <PopoverContent className="w-[min(400px,calc(100vw-2rem))] p-0" align="start">
             <div className="flex flex-col">
               <div className="max-h-[300px] overflow-y-auto p-3">
                 <div className="mb-4">

--- a/client/src/containers/scenario-dashboard-container/components/meta-scenario-filters/climate-filter/index.tsx
+++ b/client/src/containers/scenario-dashboard-container/components/meta-scenario-filters/climate-filter/index.tsx
@@ -59,7 +59,7 @@ export const ClimateFilter = () => {
             <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-[400px] p-0" align="start">
+        <PopoverContent className="w-[min(400px,calc(100vw-2rem))] p-0" align="start">
           <div className="flex flex-col">
             <div className="max-h-[350px] overflow-y-auto p-3">
               <div className="mb-4">

--- a/client/src/containers/scenario-dashboard-container/components/meta-scenario-filters/index.tsx
+++ b/client/src/containers/scenario-dashboard-container/components/meta-scenario-filters/index.tsx
@@ -11,7 +11,7 @@ export default function MetaIndicatorsFilters() {
     <div className="w-full bg-white">
       <div className="dashboard-container mx-auto pt-6">
         <p>Filter scenarios by key dimensions</p>
-        <div className="flex h-fit w-full gap-6 pt-6 pb-2">
+        <div className="grid grid-cols-1 gap-6 pt-6 pb-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
           <ClimateFilter />
           <TypologiesFilter />
           <EnergyFilter />

--- a/client/src/containers/scenario-dashboard-container/components/meta-scenario-filters/skeletons/meta-indicators-filter-skeleton.tsx
+++ b/client/src/containers/scenario-dashboard-container/components/meta-scenario-filters/skeletons/meta-indicators-filter-skeleton.tsx
@@ -3,7 +3,7 @@ import { AdvancedFilterSkeleton } from "@/containers/scenario-dashboard-containe
 export default function MetaIndicatorsFilterSkeleton(): React.ReactElement {
   return (
     <div className="w-full bg-white">
-      <div className="dashboard-container mx-auto flex h-fit w-full gap-6 pt-6 pb-2">
+      <div className="dashboard-container mx-auto grid grid-cols-1 gap-6 pt-6 pb-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
         <AdvancedFilterSkeleton />
         <AdvancedFilterSkeleton />
         <AdvancedFilterSkeleton />

--- a/client/src/containers/scenario-dashboard-container/components/meta-scenario-filters/typologies-filter/index.tsx
+++ b/client/src/containers/scenario-dashboard-container/components/meta-scenario-filters/typologies-filter/index.tsx
@@ -59,7 +59,7 @@ export const TypologiesFilter = () => {
             <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-[400px] p-0" align="start">
+        <PopoverContent className="w-[min(400px,calc(100vw-2rem))] p-0" align="start">
           <div className="flex flex-col">
             <div className="max-h-[350px] overflow-y-auto p-3">
               <div className="mb-4">

--- a/client/src/containers/scenario-dashboard-container/components/meta-scenario-filters/typologies-filter/typologies-filter-row.tsx
+++ b/client/src/containers/scenario-dashboard-container/components/meta-scenario-filters/typologies-filter/typologies-filter-row.tsx
@@ -53,7 +53,7 @@ export const TypologiesFilterRow = ({ prefix }: RowFilterProps) => {
               <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
             </button>
           </PopoverTrigger>
-          <PopoverContent className="w-[400px] p-0" align="start">
+          <PopoverContent className="w-[min(400px,calc(100vw-2rem))] p-0" align="start">
             <div className="flex flex-col">
               <div className="max-h-[300px] overflow-y-auto p-3">
                 <div className="mb-4">

--- a/client/src/containers/scenario-dashboard-container/components/plots-section/index.tsx
+++ b/client/src/containers/scenario-dashboard-container/components/plots-section/index.tsx
@@ -26,7 +26,7 @@ export default function ScenarioExplorationPlotsSection() {
       <Suspense fallback={<TabsSectionSkeleton />}>
         <TabsSection />
       </Suspense>
-      <div className="dashboard-container mx-auto flex gap-6 pb-24 lg:gap-8">
+      <div className="dashboard-container mx-auto flex flex-col gap-6 pb-24 lg:flex-row lg:gap-8">
         <Suspense fallback={<PlotGridSkeleton />}>
           <PlotGrid />
         </Suspense>

--- a/client/src/containers/scenario-dashboard-container/components/plots-section/tabs-section.tsx
+++ b/client/src/containers/scenario-dashboard-container/components/plots-section/tabs-section.tsx
@@ -14,7 +14,7 @@ export function TabsSectionSkeleton() {
           <button
             key={index}
             className={cn(
-              "w-full cursor-pointer rounded-t-md px-4 py-3 text-xs font-bold uppercase",
+              "w-full cursor-pointer rounded-t-md px-2 py-3 text-xs font-bold whitespace-nowrap uppercase sm:px-4",
               "general" === tab.tabTitle
                 ? "bg-background border border-b-0"
                 : "border-b bg-white hover:bg-stone-50",
@@ -40,7 +40,7 @@ export function TabsSection() {
           <button
             key={index}
             className={cn(
-              "w-full cursor-pointer rounded-t-md px-4 py-3 text-xs font-bold uppercase",
+              "w-full cursor-pointer rounded-t-md px-2 py-3 text-xs font-bold whitespace-nowrap uppercase sm:px-4",
               selectedTab.tabTitle === tab.tabTitle
                 ? "bg-background border border-b-0"
                 : "border-b bg-white hover:bg-stone-50",

--- a/client/src/containers/scenario-dashboard-container/components/runs-pannel/runs-panel.tsx
+++ b/client/src/containers/scenario-dashboard-container/components/runs-pannel/runs-panel.tsx
@@ -19,7 +19,7 @@ export default function RunsPanel({ prefix }: Props) {
   const showMetric = useShowReasonsForConcern({});
 
   return (
-    <div className="mx-auto flex w-120 flex-col gap-6">
+    <div className="mx-auto flex w-full max-w-120 flex-col gap-6">
       <NavigateToCompareScenarios />
       <RunHeader runs={result.runs} prefix={prefix} />
 
@@ -36,7 +36,7 @@ export default function RunsPanel({ prefix }: Props) {
 
 export function RunsPanelSkeleton() {
   return (
-    <div className="mt-8 w-120 animate-pulse space-y-6">
+    <div className="mt-8 w-full max-w-120 animate-pulse space-y-6">
       <div className="h-10 w-full rounded-[4px] bg-stone-200" />
       <div className="h-10 w-full rounded-[4px] bg-stone-200" />
       <div className="h-10 w-full rounded-[4px] bg-stone-200" />

--- a/client/src/containers/scenario-dashboard-container/index.tsx
+++ b/client/src/containers/scenario-dashboard-container/index.tsx
@@ -13,7 +13,7 @@ export default function ScenarioDashboardContainer() {
   return (
     <>
       <ScenarioDashboardHero>
-        <div className="dashboard-container mt-14 mb-16 flex w-full items-end gap-8">
+        <div className="dashboard-container mt-14 mb-16 flex w-full flex-col items-start gap-2 md:flex-row md:items-end md:gap-8">
           <Heading variant="dark" size="5xl" as="h1" id="hero-title" className="text-left">
             Scenario Dashboard
           </Heading>

--- a/client/src/hooks/use-scroll.ts
+++ b/client/src/hooks/use-scroll.ts
@@ -14,6 +14,7 @@ export function useScroll() {
   const [direction, setDirection] = useState<ScrollDirection>("up");
   const lastY = useRef(0);
   const ticking = useRef(false);
+  const rafId = useRef<number | null>(null);
 
   useEffect(() => {
     const update = () => {
@@ -24,12 +25,13 @@ export function useScroll() {
       }
       setY(currentY);
       ticking.current = false;
+      rafId.current = null;
     };
 
     const onScroll = () => {
       if (!ticking.current) {
         ticking.current = true;
-        window.requestAnimationFrame(update);
+        rafId.current = window.requestAnimationFrame(update);
       }
     };
 
@@ -38,7 +40,13 @@ export function useScroll() {
     // Initialise via the rAF path so we never call setState synchronously in
     // the effect body (picks up the position if the page loads pre-scrolled).
     onScroll();
-    return () => window.removeEventListener("scroll", onScroll);
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      if (rafId.current !== null) {
+        window.cancelAnimationFrame(rafId.current);
+        rafId.current = null;
+      }
+    };
   }, []);
 
   return { y, direction };

--- a/client/src/hooks/use-scroll.ts
+++ b/client/src/hooks/use-scroll.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export type ScrollDirection = "up" | "down";
+
+/**
+ * Tracks the window scroll position and direction, throttled to one update per
+ * animation frame. A small delta threshold avoids direction flicker from tiny
+ * sub-pixel scrolls (e.g. momentum settling on mobile).
+ */
+export function useScroll() {
+  const [y, setY] = useState(0);
+  const [direction, setDirection] = useState<ScrollDirection>("up");
+  const lastY = useRef(0);
+  const ticking = useRef(false);
+
+  useEffect(() => {
+    const update = () => {
+      const currentY = window.scrollY;
+      if (Math.abs(currentY - lastY.current) > 4) {
+        setDirection(currentY > lastY.current ? "down" : "up");
+        lastY.current = currentY;
+      }
+      setY(currentY);
+      ticking.current = false;
+    };
+
+    const onScroll = () => {
+      if (!ticking.current) {
+        ticking.current = true;
+        window.requestAnimationFrame(update);
+      }
+    };
+
+    lastY.current = window.scrollY;
+    window.addEventListener("scroll", onScroll, { passive: true });
+    // Initialise via the rAF path so we never call setState synchronously in
+    // the effect body (picks up the position if the page loads pre-scrolled).
+    onScroll();
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return { y, direction };
+}


### PR DESCRIPTION
## Summary

First-pass mobile responsiveness improvements identified via Playwright audit at 375×812 (iPhone 12 Pro). Follows an 80/20 principle: prose pages are fully fixed, data-heavy dashboard pages receive best-effort layout fixes that prevent overflow without requiring a full redesign.

### Root cause

`.dashboard-container` had a hardcoded `px-12` (48px each side), leaving only 279px of usable content width at 375px. This was the systemic root cause of most overflow issues and is fixed first.

## Changes by file

**Systemic fix**
- `client/src/app/globals.css` — `dashboard-container` padding now scales: `px-4 sm:px-6 md:px-8 lg:px-12`. Preserves the desktop 48px padding; everything using this class benefits.

**Prose pages (fully fixed)**
- `client/src/containers/landing-page-container/newsletter-subscription-container.tsx` — Hero newsletter section stacks vertically on mobile (`flex-col` / `md:flex-row`); decorative email illustration hidden on mobile so the form takes full width.
- `client/src/containers/learn-by-topic-container/index.tsx` — Removed a stray `<div className="grid min-h-screen place-content-center" />` that was rendering a full-viewport-height blank area between the hero and the cross-links.

**Global layout components**
- `client/src/components/custom/scroll-to-top-button.tsx` — New `ScrollToTopButton` component providing a quick jump-to-top affordance on long pages; improves navigation on mobile and desktop.
- `client/src/hooks/use-scroll.ts` — New `useScroll` hook used to detect scroll position for the `ScrollToTopButton`.
- `client/src/app/layout.tsx` — Layout updated to include the `ScrollToTopButton` and wire up `useScroll` for improved mobile navigation.
- `client/src/components/layout/navbar/navbar.tsx` — Wordmark "Scenario Compass Initiative" font size scales down on xs (`text-lg leading-tight sm:text-2xl sm:leading-10`) so it fits in the `h-14` navbar on narrow viewports without wrapping.
- `client/src/components/custom/feedback-button.tsx` — Floating rotated feedback tab hidden on mobile (`hidden sm:flex`). The `-rotate-90 fixed` positioning doesn't translate cleanly below 640px, and the tab is a secondary affordance.
- `client/src/components/layout/footer/index.tsx` — Nav links get `py-3` on mobile (removed at `lg:`) and the Contact + social icon links get touch targets enlarged to 44px+ via `py-3` / `-m-3 p-3` negative-margin trick respectively.

**Scenario Dashboard (best-effort, no redesign)**
- `client/src/containers/scenario-dashboard-container/index.tsx` — Hero heading + "See Single Scenario details" link now stack vertically on mobile (`flex-col` / `md:flex-row`).
- `client/src/containers/scenario-dashboard-container/components/meta-scenario-filters/index.tsx` — 5-column filter bar converted from `flex` to a responsive grid: `grid-cols-1 → sm:grid-cols-2 → md:grid-cols-3 → lg:grid-cols-5`. Prevents the ~476px horizontal overflow.
- `client/src/containers/scenario-dashboard-container/components/meta-scenario-filters/skeletons/meta-indicators-filter-skeleton.tsx` — Skeleton updated to match the same grid so there's no layout shift when Suspense resolves.
- `client/src/containers/scenario-dashboard-container/components/meta-scenario-filters/climate-filter/index.tsx` + `typologies-filter/index.tsx` — `PopoverContent` width changed from a hardcoded `w-[400px]` to `w-[min(400px,calc(100vw-2rem))]`. Popovers now fit inside the viewport on any screen width.
- `client/src/containers/scenario-dashboard-container/components/plots-section/index.tsx` — PlotGrid + RunsPanel wrapper switches from always-row to `flex-col lg:flex-row`. Charts stack vertically below `lg` instead of overflowing. D3 charts themselves are not made mobile-native (out of scope for 80/20).

## What's intentionally out of scope

- D3 chart interactivity and sizing on mobile (would require a full responsive chart overhaul)
- About page members photo grid (`h-[300px]` portrait cards in 2-col) — acceptable long scroll, photos can't meaningfully shrink further
- Pre-existing bugs: mobile sheet logo always renders dark variant regardless of sheet theme; `console.log` of email on newsletter submit
